### PR TITLE
Add Laboratory B / btvmesh and Toronto Mesh

### DIFF
--- a/data/meshes.json
+++ b/data/meshes.json
@@ -99,4 +99,19 @@
       "zip": "11231"
     }]
   }
+  "Laboratory B": {
+    "url": "https://laboratoryb.org/",
+    "locations": [{
+      "name": "Laboratory B, Burlinton, VT",
+      "zip": "05401"
+    }]
+  }
+  "Toronto Mesh": {
+    "url": "https://tomesh.net/",
+    "locations": [{
+      "name": "Free Geek Toronto, Toronto, ON",
+      "lat": "43.640995",
+      "lon": "-79.4245652"
+    }]
+  }
 }

--- a/data/meshes.json
+++ b/data/meshes.json
@@ -114,4 +114,12 @@
       "lon": "-79.4245652"
     }]
   }
+  "Newport Mesh": {
+    "url": "https://newportmesh.org/",
+    "locations": [{
+    "name": "Mephramagog Arts Collaborative / The 99 Gallery, Newport, VT",
+    "zip": "05855"
+    }]
+  }
+
 }


### PR DESCRIPTION
btvmesh is a project in its infancy led by members of Laboratory B;
Toronto Mesh is more developed, and its primary meeting location is
usually at Free Geek Toronto.

I'm reaching out to @Darkdrgn2k to confirm the latter bit, though.